### PR TITLE
Add spawn worker pool option

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -13,6 +13,7 @@ ALIASES = {
     'eventlet': 'celery.concurrency.eventlet:TaskPool',
     'gevent': 'celery.concurrency.gevent:TaskPool',
     'solo': 'celery.concurrency.solo:TaskPool',
+    'spawn': 'celery.concurrency.spawn:TaskPool',
     'processes': 'celery.concurrency.prefork:TaskPool',  # XXX compat alias
 }
 

--- a/celery/concurrency/spawn.py
+++ b/celery/concurrency/spawn.py
@@ -1,0 +1,24 @@
+"""Spawn execution pool (multiprocessing using the spawn start method)."""
+import os
+
+from billiard import set_start_method
+
+from celery.concurrency import prefork
+
+__all__ = ("TaskPool",)
+
+
+class TaskPool(prefork.TaskPool):
+    """TaskPool that uses the spawn start method."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("forking_enable", False)
+        super().__init__(*args, **kwargs)
+
+    def on_start(self):
+        try:
+            set_start_method("spawn", force=True)
+        except Exception:
+            pass
+        os.environ.setdefault("FORKED_BY_MULTIPROCESSING", "1")
+        super().on_start()

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -136,6 +136,7 @@ Celery is…
         - **Concurrency**
 
             - prefork (multiprocessing),
+            - spawn (multiprocessing spawn),
             - Eventlet_, gevent_
             - thread (multithreaded)
             - `solo` (single threaded)

--- a/docs/internals/reference/celery.concurrency.spawn.rst
+++ b/docs/internals/reference/celery.concurrency.spawn.rst
@@ -1,0 +1,11 @@
+============================================================
+ ``celery.concurrency.spawn``
+============================================================
+
+.. contents::
+    :local:
+.. currentmodule:: celery.concurrency.spawn
+
+.. automodule:: celery.concurrency.spawn
+    :members:
+    :undoc-members:

--- a/docs/internals/reference/index.rst
+++ b/docs/internals/reference/index.rst
@@ -17,6 +17,7 @@
     celery.concurrency
     celery.concurrency.solo
     celery.concurrency.prefork
+    celery.concurrency.spawn
     celery.concurrency.eventlet
     celery.concurrency.gevent
     celery.concurrency.thread

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -20,6 +20,8 @@ Overview of Concurrency Options
 
 - `prefork`: The default option, ideal for CPU-bound tasks and most use cases.
   It is robust and recommended unless there's a specific need for another model.
+- `spawn`: Uses the multiprocessing spawn start method for compatibility with
+  libraries that cannot be safely forked.
 - `eventlet` and `gevent`: Designed for IO-bound tasks, these models use
   greenlets for high concurrency. Note that certain features, like `soft_timeout`,
   are not available in these modes.  These have detailed documentation pages

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3731,6 +3731,8 @@ Custom Component Classes (advanced)
 ~~~~~~~~~~~~~~~
 
 Default: ``"prefork"`` (``celery.concurrency.prefork:TaskPool``).
+Available options include ``prefork`` and ``spawn`` which both use the
+``multiprocessing`` module but differ in their process start method.
 
 Name of the pool class used by the worker.
 

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -416,7 +416,7 @@ Remote control
     commands from the command-line. It supports all of the commands
     listed below. See :ref:`monitoring-control` for more information.
 
-:pool support: *prefork, eventlet, gevent, thread*, blocking:*solo* (see note)
+:pool support: *prefork, spawn, eventlet, gevent, thread*, blocking:*solo* (see note)
 :broker support: *amqp, redis*
 
 Workers have the ability to be remote controlled using a high-priority
@@ -496,7 +496,7 @@ Commands
 
 ``revoke``: Revoking tasks
 --------------------------
-:pool support: all, terminate only supported by prefork, eventlet and gevent
+:pool support: all, terminate only supported by prefork, spawn, eventlet and gevent
 :broker support: *amqp, redis*
 :command: :program:`celery -A proj control revoke <task_id>`
 
@@ -617,7 +617,7 @@ at this point.
 
 ``revoke_by_stamped_headers``: Revoking tasks by their stamped headers
 ----------------------------------------------------------------------
-:pool support: all, terminate only supported by prefork and eventlet
+:pool support: all, terminate only supported by prefork, spawn and eventlet
 :broker support: *amqp, redis*
 :command: :program:`celery -A proj control revoke_by_stamped_headers <header=value>`
 
@@ -685,7 +685,7 @@ Time Limits
 
 .. versionadded:: 2.0
 
-:pool support: *prefork/gevent (see note below)*
+:pool support: *prefork/spawn/gevent (see note below)*
 
 .. sidebar:: Soft, or hard?
 
@@ -792,7 +792,7 @@ Max tasks per child setting
 
 .. versionadded:: 2.0
 
-:pool support: *prefork*
+:pool support: *prefork/spawn*
 
 With this option you can configure the maximum number of tasks
 a worker can execute before it's replaced by a new process.
@@ -811,7 +811,7 @@ Max memory per child setting
 
 .. versionadded:: 4.0
 
-:pool support: *prefork*
+:pool support: *prefork/spawn*
 
 With this option you can configure the maximum amount of resident
 memory a worker can execute before it's replaced by a new process.
@@ -830,7 +830,7 @@ Autoscaling
 
 .. versionadded:: 2.2
 
-:pool support: *prefork*, *gevent*
+:pool support: *prefork/spawn*, *gevent*
 
 The *autoscaler* component is used to dynamically resize the pool
 based on load:


### PR DESCRIPTION
## Summary
- add new `spawn` worker pool implementation that uses the multiprocessing spawn start method
- update pool alias registry
- document the new pool in the docs and mention it in configuration, introduction, concurrency and workers guides

## Testing
- `pre-commit run --files celery/concurrency/spawn.py celery/concurrency/__init__.py docs/getting-started/introduction.rst docs/internals/reference/index.rst docs/userguide/concurrency/index.rst docs/userguide/configuration.rst docs/internals/reference/celery.concurrency.spawn.rst docs/userguide/workers.rst`
- `pytest -k spawn` *(fails: ModuleNotFoundError: No module named 'kombu')*

------
https://chatgpt.com/codex/tasks/task_b_686cb834fd5c833093ecf45159c43090