### PR TITLE
Add spawn worker pool option

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -10,6 +10,7 @@ __all__ = ('get_implementation', 'get_available_pool_names',)
 
 ALIASES = {
     'prefork': 'celery.concurrency.prefork:TaskPool',
+    'spawn': 'celery.concurrency.spawn:TaskPool',
     'eventlet': 'celery.concurrency.eventlet:TaskPool',
     'gevent': 'celery.concurrency.gevent:TaskPool',
     'solo': 'celery.concurrency.solo:TaskPool',

--- a/celery/concurrency/spawn.py
+++ b/celery/concurrency/spawn.py
@@ -1,0 +1,12 @@
+"""Spawn execution pool."""
+from .prefork import TaskPool as PreforkTaskPool
+
+__all__ = ("TaskPool",)
+
+
+class TaskPool(PreforkTaskPool):
+    """Multiprocessing Pool using the 'spawn' start method."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs['forking_enable'] = False
+        super().__init__(*args, **kwargs)

--- a/docs/internals/reference/celery.concurrency.spawn.rst
+++ b/docs/internals/reference/celery.concurrency.spawn.rst
@@ -1,0 +1,11 @@
+=============================================================
+ ``celery.concurrency.spawn``
+=============================================================
+
+.. contents::
+   :local:
+.. currentmodule:: celery.concurrency.spawn
+
+.. automodule:: celery.concurrency.spawn
+    :members:
+    :undoc-members:

--- a/docs/internals/reference/index.rst
+++ b/docs/internals/reference/index.rst
@@ -17,6 +17,7 @@
     celery.concurrency
     celery.concurrency.solo
     celery.concurrency.prefork
+    celery.concurrency.spawn
     celery.concurrency.eventlet
     celery.concurrency.gevent
     celery.concurrency.thread

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -595,3 +595,4 @@ questionark
 amongst
 requeue
 wildcard
+spawn

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -20,6 +20,8 @@ Overview of Concurrency Options
 
 - `prefork`: The default option, ideal for CPU-bound tasks and most use cases.
   It is robust and recommended unless there's a specific need for another model.
+- `spawn`: Uses the "spawn" start method to create new processes. This is
+  helpful when working with libraries that are not fork-safe.
 - `eventlet` and `gevent`: Designed for IO-bound tasks, these models use
   greenlets for high concurrency. Note that certain features, like `soft_timeout`,
   are not available in these modes.  These have detailed documentation pages

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3731,6 +3731,8 @@ Custom Component Classes (advanced)
 ~~~~~~~~~~~~~~~
 
 Default: ``"prefork"`` (``celery.concurrency.prefork:TaskPool``).
+Another built-in option is ``"spawn"`` which creates child processes using the
+``spawn`` start method.
 
 Name of the pool class used by the worker.
 

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -163,6 +163,7 @@ class test_get_available_pool_names:
     def test_no_concurrent_futures__returns_no_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',
@@ -176,6 +177,7 @@ class test_get_available_pool_names:
     def test_concurrent_futures__returns_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',


### PR DESCRIPTION
## Summary
- introduce a new `spawn` worker pool
- document the new pool and update configuration docs
- include `spawn` in reference docs and spell-check wordlist
- test available pool names with new option

## Testing
- `pytest t/unit/concurrency/test_concurrency.py::test_get_available_pool_names -q`

------
https://chatgpt.com/codex/tasks/task_b_686cb834fd5c833093ecf45159c43090