### PR TITLE
Add spawn worker pool

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -10,6 +10,7 @@ __all__ = ('get_implementation', 'get_available_pool_names',)
 
 ALIASES = {
     'prefork': 'celery.concurrency.prefork:TaskPool',
+    'spawn': 'celery.concurrency.spawn:TaskPool',
     'eventlet': 'celery.concurrency.eventlet:TaskPool',
     'gevent': 'celery.concurrency.gevent:TaskPool',
     'solo': 'celery.concurrency.solo:TaskPool',

--- a/celery/concurrency/spawn.py
+++ b/celery/concurrency/spawn.py
@@ -14,9 +14,6 @@ class TaskPool(PreforkTaskPool):
     start_method = "spawn"
 
     def on_start(self):
-        try:
-            billiard.set_start_method(self.start_method, force=True)
-        except RuntimeError:
-            pass
+        billiard.set_start_method(self.start_method, force=True)
         os.environ.setdefault("FORKED_BY_MULTIPROCESSING", "1")
         super().on_start()

--- a/celery/concurrency/spawn.py
+++ b/celery/concurrency/spawn.py
@@ -1,0 +1,22 @@
+"""Spawn execution pool."""
+import os
+
+import billiard
+
+from .prefork import TaskPool as PreforkTaskPool
+
+__all__ = ("TaskPool",)
+
+
+class TaskPool(PreforkTaskPool):
+    """Multiprocessing Pool using the ``spawn`` start method."""
+
+    start_method = "spawn"
+
+    def on_start(self):
+        try:
+            billiard.set_start_method(self.start_method, force=True)
+        except RuntimeError:
+            pass
+        os.environ.setdefault("FORKED_BY_MULTIPROCESSING", "1")
+        super().on_start()

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -136,6 +136,7 @@ Celery is…
         - **Concurrency**
 
             - prefork (multiprocessing),
+            - spawn (multiprocessing using the spawn method),
             - Eventlet_, gevent_
             - thread (multithreaded)
             - `solo` (single threaded)

--- a/docs/history/whatsnew-5.5.rst
+++ b/docs/history/whatsnew-5.5.rst
@@ -358,3 +358,11 @@ actually needed, which can be useful in certain deployment scenarios where you w
 more control over database schema management.
 
 See :ref:`conf-database-result-backend` for complete documentation.
+
+Spawn Pool Option
+-----------------
+
+Added a new ``spawn`` pool implementation. This pool uses Python's
+``spawn`` start method when launching worker processes which is helpful
+when libraries are not fork-safe (for example CUDA based frameworks).
+Enable it with ``-P spawn`` on the command line.

--- a/docs/internals/guide.rst
+++ b/docs/internals/guide.rst
@@ -267,7 +267,7 @@ Module Overview
 
 - celery.concurrency
 
-    Execution pool implementations (prefork, eventlet, gevent, solo, thread).
+    Execution pool implementations (prefork, spawn, eventlet, gevent, solo, thread).
 
 - celery.db
 

--- a/docs/internals/reference/celery.concurrency.spawn.rst
+++ b/docs/internals/reference/celery.concurrency.spawn.rst
@@ -1,0 +1,11 @@
+==============================================================
+ ``celery.concurrency.spawn``
+==============================================================
+
+.. contents::
+    :local:
+.. currentmodule:: celery.concurrency.spawn
+
+.. automodule:: celery.concurrency.spawn
+    :members:
+    :undoc-members:

--- a/docs/internals/reference/index.rst
+++ b/docs/internals/reference/index.rst
@@ -17,6 +17,7 @@
     celery.concurrency
     celery.concurrency.solo
     celery.concurrency.prefork
+    celery.concurrency.spawn
     celery.concurrency.eventlet
     celery.concurrency.gevent
     celery.concurrency.thread

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -20,6 +20,8 @@ Overview of Concurrency Options
 
 - `prefork`: The default option, ideal for CPU-bound tasks and most use cases.
   It is robust and recommended unless there's a specific need for another model.
+- `spawn`: Uses Python's ``spawn`` start method. Helpful when libraries are not
+  fork-safe, for example when using CUDA.
 - `eventlet` and `gevent`: Designed for IO-bound tasks, these models use
   greenlets for high concurrency. Note that certain features, like `soft_timeout`,
   are not available in these modes.  These have detailed documentation pages
@@ -35,6 +37,7 @@ Overview of Concurrency Options
 
     eventlet
     gevent
+    spawn
 
 .. note::
     While alternative models like `eventlet` and `gevent` are available, they

--- a/docs/userguide/concurrency/spawn.rst
+++ b/docs/userguide/concurrency/spawn.rst
@@ -1,0 +1,18 @@
+.. _concurrency-spawn:
+
+=======================
+ Spawn Start Method
+=======================
+
+Celery can use Python's ``spawn`` start method to create worker processes.
+This is useful when libraries used by your tasks are not fork-safe, for
+example when working with CUDA.
+
+Enable this pool using the :option:`celery worker -P` option:
+
+.. code-block:: console
+
+    $ celery -A proj worker -P spawn -c 4
+
+When using ``spawn`` each worker starts in a fresh Python interpreter
+so any global state must be initialized in the child process.

--- a/extra/zsh-completion/celery.zsh
+++ b/extra/zsh-completion/celery.zsh
@@ -40,7 +40,7 @@ case "$words[1]" in
     worker)
     _arguments \
     '(-C --concurrency=)'{-C,--concurrency=}'[Number of child processes processing the queue. The default is the number of CPUs.]' \
-    '(--pool)--pool=:::(prefork eventlet gevent solo)' \
+    '(--pool)--pool=:::(prefork spawn eventlet gevent solo)' \
     '(--purge --discard)'{--discard,--purge}'[Purges all waiting tasks before the daemon is started.]' \
     '(-f --logfile=)'{-f,--logfile=}'[Path to log file. If no logfile is specified, stderr is used.]' \
     '(--loglevel=)--loglevel=:::(critical error warning info debug)' \

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -163,6 +163,7 @@ class test_get_available_pool_names:
     def test_no_concurrent_futures__returns_no_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',
@@ -176,6 +177,7 @@ class test_get_available_pool_names:
     def test_concurrent_futures__returns_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -1,17 +1,79 @@
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-import pytest
 
 from celery.concurrency import spawn
 
 
+class MockPool:
+    """Mock pool that prevents actual process creation."""
+    started = False
+    closed = False
+    joined = False
+    terminated = False
+    _state = None
+
+    def __init__(self, *args, **kwargs):
+        self.started = True
+        self._timeout_handler = Mock()
+        self._result_handler = Mock()
+        self.maintain_pool = Mock()
+        self._state = 1  # RUN state
+        self._processes = kwargs.get('processes', 1)
+        self._proc_alive_timeout = kwargs.get('proc_alive_timeout')
+        self._pool = [Mock(pid=i) for i in range(self._processes)]
+
+    def close(self):
+        self.closed = True
+        self._state = 'CLOSE'
+
+    def join(self):
+        self.joined = True
+
+    def terminate(self):
+        self.terminated = True
+
+    def did_start_ok(self):
+        return True
+
+    def apply_async(self, *args, **kwargs):
+        pass
+
+    def terminate_job(self, *args, **kwargs):
+        pass
+
+    def restart(self, *args, **kwargs):
+        pass
+
+    def register_with_event_loop(self, loop):
+        pass
+
+    def flush(self):
+        pass
+
+    def grow(self, n=1):
+        self._processes += n
+
+    def shrink(self, n=1):
+        self._processes -= n
+
+
+class TestTaskPool(spawn.TaskPool):
+    """TaskPool that uses MockPool instead of real billiard pools."""
+    Pool = MockPool
+    BlockingPool = MockPool
+
+
 class test_spawn_TaskPool:
     @patch('billiard.set_start_method')
-    def test_on_start_sets_spawn(self, set_method):
-        pool = spawn.TaskPool(1)
+    @patch('billiard.forking_enable')
+    def test_on_start_sets_spawn(self, mock_forking_enable, set_method):
+        pool = TestTaskPool(1)
         with patch.dict(os.environ, {}, clear=True):
             pool.on_start()
             set_method.assert_called_with('spawn', force=True)
             assert os.environ['FORKED_BY_MULTIPROCESSING'] == '1'
+            # Verify the pool was created
+            assert pool._pool is not None
+            assert pool._pool.started
 

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import Mock, patch
 
-
 from celery.concurrency import spawn
 
 
@@ -76,4 +75,3 @@ class test_spawn_TaskPool:
             # Verify the pool was created
             assert pool._pool is not None
             assert pool._pool.started
-

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -1,0 +1,17 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from celery.concurrency import spawn
+
+
+class test_spawn_TaskPool:
+    @patch('billiard.set_start_method')
+    def test_on_start_sets_spawn(self, set_method):
+        pool = spawn.TaskPool(1)
+        with patch.dict(os.environ, {}, clear=True):
+            pool.on_start()
+            set_method.assert_called_with('spawn', force=True)
+            assert os.environ['FORKED_BY_MULTIPROCESSING'] == '1'
+


### PR DESCRIPTION
## Summary
- add new `spawn` concurrency pool to support libraries that are not fork-safe
- document spawn concurrency option across the docs
- describe spawn in the 5.5 changelog
- test spawn pool and update pool name tests

## Testing
- `pytest t/unit/concurrency/test_spawn.py -q` *(fails: ModuleNotFoundError: No module named 'kombu')*

------
https://chatgpt.com/codex/tasks/task_b_686cb834fd5c833093ecf45159c43090