### PR TITLE
Add spawn pool integration test

### DIFF
--- a/t/integration/test_spawn_pool.py
+++ b/t/integration/test_spawn_pool.py
@@ -1,0 +1,20 @@
+import pytest
+
+from .tasks import add
+
+
+@pytest.fixture(scope="session")
+def celery_worker_pool():
+    return "spawn"
+
+
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+def test_basic_task_spawn(manager):
+    results = []
+    for i in range(5):
+        results.append([i + i, add.delay(i, i)])
+    for expected, result in results:
+        assert result.get(timeout=10) == expected
+        assert result.status == "SUCCESS"
+        assert result.ready() is True
+        assert result.successful() is True

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -66,7 +66,7 @@ class TestTaskPool(spawn.TaskPool):
 class test_spawn_TaskPool:
     @patch('billiard.set_start_method')
     @patch('billiard.forking_enable')
-    def test_on_start_sets_spawn(self, set_method, mock_forking_enable):
+    def test_on_start_sets_spawn(self, mock_forking_enable, set_method):
         pool = TestTaskPool(1)
         with patch.dict(os.environ, {}, clear=True):
             pool.on_start()


### PR DESCRIPTION
## Summary
- add new integration test running the worker with spawn pool
- fix argument order in existing spawn pool unit test

## Testing
- `pre-commit run --files t/unit/concurrency/test_spawn.py t/integration/test_spawn_pool.py`
- `PYTHONPATH=. pytest t/unit/concurrency/test_spawn.py::test_spawn_TaskPool::test_on_start_sets_spawn -q`
- `PYTHONPATH=. pytest t/integration/test_spawn_pool.py::test_basic_task_spawn -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_686e1c6215e083308c777c7eb9d1d3e1